### PR TITLE
設定画面の下部のテキストのハードコードを解消した

### DIFF
--- a/IkinariMemo/IkinariMemo/View/Settings/SettingsView.swift
+++ b/IkinariMemo/IkinariMemo/View/Settings/SettingsView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct SettingsView: View {
 
   // MARK: - Properties
+  
+  @StateObject private var viewModel: SettingsViewModel = SettingsViewModel()
 
   private let bottomTextFontSizeRatio: CGFloat = 0.016
   private let bottomTextBottomPaddingRatio: CGFloat = 0.011
@@ -44,8 +46,8 @@ struct SettingsView: View {
         Spacer()
 
         VStack {
-          Text("Version 1.0.0")
-          Text("© 2025 Masayuki Kawashima")
+          Text("Version \(viewModel.appVersion)")
+          Text("© \(viewModel.year) Masayuki Kawashima")
         }
         .padding(.bottom, screenHeight * bottomTextBottomPaddingRatio)
         .font(.system(size: screenHeight * bottomTextFontSizeRatio))

--- a/IkinariMemo/IkinariMemo/ViewModel/Settings/SettingsViewModel.swift
+++ b/IkinariMemo/IkinariMemo/ViewModel/Settings/SettingsViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  SettingsViewModel.swift
+//  IkinariMemo
+//
+//  Created by 川島真之 on 2025/09/26.
+//
+
+import Foundation
+
+class SettingsViewModel: ObservableObject {
+  
+  // MARK: - Properties
+  
+  @Published var appVersion: String
+  @Published var year: String
+  
+  // MARK: - Init
+  
+  init () {
+    self.appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
+    let year = Calendar.current.component(.year, from: Date())
+    self.year = String(year)
+  }
+}


### PR DESCRIPTION
## issue
close #132 
## やったこと
設定画面の下部のテキストについて以下の作業をした
- アプリのバージョンをBundle.main.infoDictionaryから取得して表示するようにした
- 年の表記を現在の年を取得して表示するようにした

